### PR TITLE
Add Convex Auth with tiered poll limits and UI polish

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(npm run lint:*)"
+      "Bash(npm run lint:*)",
+      "WebFetch(domain:labs.convex.dev)"
     ],
     "deny": [],
     "ask": []

--- a/app/ConvexClientProvider.tsx
+++ b/app/ConvexClientProvider.tsx
@@ -4,14 +4,17 @@ import { ConvexReactClient } from "convex/react";
 import { ConvexAuthProvider } from "@convex-dev/auth/react";
 import { ReactNode } from "react";
 import { AutoAnonymousAuth } from "@/components/AutoAnonymousAuth";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 export function ConvexClientProvider({ children }: { children: ReactNode }) {
   return (
     <ConvexAuthProvider client={convex}>
-      <AutoAnonymousAuth />
-      {children}
+      <TooltipProvider delayDuration={0}>
+        <AutoAnonymousAuth />
+        {children}
+      </TooltipProvider>
     </ConvexAuthProvider>
   );
 }

--- a/app/ConvexClientProvider.tsx
+++ b/app/ConvexClientProvider.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { ConvexProvider, ConvexReactClient } from "convex/react";
+import { ConvexReactClient } from "convex/react";
+import { ConvexAuthProvider } from "@convex-dev/auth/react";
 import { ReactNode } from "react";
+import { AutoAnonymousAuth } from "@/components/AutoAnonymousAuth";
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 export function ConvexClientProvider({ children }: { children: ReactNode }) {
-  return <ConvexProvider client={convex}>{children}</ConvexProvider>;
+  return (
+    <ConvexAuthProvider client={convex}>
+      <AutoAnonymousAuth />
+      {children}
+    </ConvexAuthProvider>
+  );
 }

--- a/app/admin/[pollId]/page.tsx
+++ b/app/admin/[pollId]/page.tsx
@@ -450,8 +450,8 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
   const totalCount = topics.length;
 
   return (
-    <div className="min-h-screen bg-background p-4 py-8">
-      <div className="max-w-6xl mx-auto space-y-6">
+    <div className="min-h-screen bg-background p-4 py-4">
+      <div className="max-w-6xl mx-auto space-y-3">
         {/* Error Message */}
         <ErrorMessage message={error} onDismiss={() => setError(null)} />
 

--- a/app/admin/[pollId]/page.tsx
+++ b/app/admin/[pollId]/page.tsx
@@ -10,7 +10,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Loader2, Plus, Download, GripVertical, Trash2, ChevronUp, ChevronDown } from "lucide-react";
+import { Loader2, Plus, Download, GripVertical, Trash2, HelpCircle, RotateCcw, Share2, Check, ExternalLink, Lock, Unlock, ChevronDown } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useConfirm } from "@/components/ui/use-confirm";
 import { ShareLinks } from "@/components/ShareLinks";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
@@ -54,9 +56,14 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
   const unclaimTopic = useMutation(api.topics.unclaimTopic);
   const deletePoll = useMutation(api.polls.deletePoll);
 
+  const [titleHelpOpen, setTitleHelpOpen] = useState(false);
   const [draggedTopicId, setDraggedTopicId] = useState<Id<"topics"> | null>(null);
   const [previewTopics, setPreviewTopics] = useState<typeof topics | null>(null);
   const [optimisticOrder, setOptimisticOrder] = useState<Id<"topics">[] | null>(null);
+  // Refs for touch drag (avoid stale closure issues in event handlers)
+  const draggedTopicIdRef = useRef<Id<"topics"> | null>(null);
+  const previewTopicsRef = useRef<typeof topics | null>(null);
+  const topicsContainerRef = useRef<HTMLDivElement>(null);
   const [editingTopicId, setEditingTopicId] = useState<Id<"topics"> | null>(null);
   const [editingTopicLabel, setEditingTopicLabel] = useState("");
   const editingCancelledRef = useRef(false);
@@ -244,46 +251,65 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
     }
   };
 
-  const handleMoveUp = async (topicId: Id<"topics">) => {
-    if (!topics) return;
-    const currentIndex = topics.findIndex((t) => t._id === topicId);
-    if (currentIndex <= 0) return; // Already at top
+  // Prevent page scroll while touch-dragging (must be passive:false, so use native listener)
+  useEffect(() => {
+    const el = topicsContainerRef.current;
+    if (!el) return;
+    const preventScroll = (e: TouchEvent) => {
+      if (draggedTopicIdRef.current) e.preventDefault();
+    };
+    el.addEventListener("touchmove", preventScroll, { passive: false });
+    return () => el.removeEventListener("touchmove", preventScroll);
+  }, []);
 
-    const reordered = [...topics];
-    [reordered[currentIndex - 1], reordered[currentIndex]] = [reordered[currentIndex], reordered[currentIndex - 1]];
-    const finalOrderIds = reordered.map((t) => t._id);
-
-    setOptimisticOrder(finalOrderIds);
-
-    try {
-      await reorderTopics({
-        pollId,
-        adminToken,
-        topicIds: finalOrderIds,
-      });
-    } catch (error) {
-      setError(getErrorMessage(error));
-      setOptimisticOrder(null);
-    }
+  const handleTouchStart = (topicId: Id<"topics">) => {
+    draggedTopicIdRef.current = topicId;
+    previewTopicsRef.current = null;
+    setDraggedTopicId(topicId);
+    setPreviewTopics(null);
   };
 
-  const handleMoveDown = async (topicId: Id<"topics">) => {
-    if (!topics) return;
-    const currentIndex = topics.findIndex((t) => t._id === topicId);
-    if (currentIndex < 0 || currentIndex >= topics.length - 1) return; // Already at bottom
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const currentDraggedId = draggedTopicIdRef.current;
+    if (!currentDraggedId || !topics) return;
 
-    const reordered = [...topics];
-    [reordered[currentIndex], reordered[currentIndex + 1]] = [reordered[currentIndex + 1], reordered[currentIndex]];
-    const finalOrderIds = reordered.map((t) => t._id);
+    const touch = e.touches[0];
+    const el = document.elementFromPoint(touch.clientX, touch.clientY);
+    const topicEl = el?.closest("[data-topic-id]") as HTMLElement | null;
+    if (!topicEl) return;
 
+    const targetId = topicEl.dataset.topicId as Id<"topics"> | undefined;
+    if (!targetId || targetId === currentDraggedId) return;
+
+    const source = previewTopicsRef.current ?? topics;
+    const draggedIndex = source.findIndex((t) => t._id === currentDraggedId);
+    const targetIndex = source.findIndex((t) => t._id === targetId);
+    if (draggedIndex === -1 || targetIndex === -1) return;
+
+    const reordered = [...source];
+    const [removed] = reordered.splice(draggedIndex, 1);
+    reordered.splice(targetIndex, 0, removed);
+
+    previewTopicsRef.current = reordered;
+    setPreviewTopics(reordered);
+  };
+
+  const handleTouchEnd = async () => {
+    const currentDraggedId = draggedTopicIdRef.current;
+    const currentPreview = previewTopicsRef.current;
+
+    draggedTopicIdRef.current = null;
+    previewTopicsRef.current = null;
+    setDraggedTopicId(null);
+    setPreviewTopics(null);
+
+    if (!currentDraggedId || !currentPreview) return;
+
+    const finalOrderIds = currentPreview.map((t) => t._id);
     setOptimisticOrder(finalOrderIds);
 
     try {
-      await reorderTopics({
-        pollId,
-        adminToken,
-        topicIds: finalOrderIds,
-      });
+      await reorderTopics({ pollId, adminToken, topicIds: finalOrderIds });
     } catch (error) {
       setError(getErrorMessage(error));
       setOptimisticOrder(null);
@@ -319,7 +345,7 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
   const handleDeletePoll = async () => {
     const confirmed = await confirm({
       title: "Delete Poll",
-      description: "Are you sure you want to permanently delete this poll? This will delete all topics, groups, and submissions. This action cannot be undone.",
+      description: "Permanently delete this poll and all associated data? This action cannot be undone.",
       actionLabel: "Delete Poll",
       destructive: true,
     });
@@ -456,7 +482,18 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
         <ErrorMessage message={error} onDismiss={() => setError(null)} />
 
         {/* Header */}
-        <Card>
+        <Card className="relative">
+          <Tooltip open={titleHelpOpen} onOpenChange={setTitleHelpOpen}>
+            <TooltipTrigger asChild>
+              <button
+                className="absolute top-3 right-3 text-muted-foreground hover:text-foreground transition-colors"
+                onClick={() => setTitleHelpOpen(v => !v)}
+              >
+                <HelpCircle className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left">Tap on title or description to edit it. Share the poll link. Lock the poll. Preview the poll.</TooltipContent>
+          </Tooltip>
           <CardHeader>
             {titleEdit.isEditing ? (
               <Input
@@ -472,7 +509,7 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
               />
             ) : (
               <CardTitle
-                className="text-2xl cursor-pointer hover:text-info transition-colors bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent hover:from-info hover:to-info/70"
+                className="text-2xl cursor-pointer text-info hover:text-info/80 transition-colors"
                 onClick={titleEdit.startEditing}
                 title="Click to edit"
               >
@@ -494,14 +531,52 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
               />
             ) : (
               <CardDescription
-                className="text-base mt-2 cursor-pointer hover:text-info transition-colors"
+                className="text-base mt-2 cursor-pointer text-info hover:text-info/80 transition-colors"
                 onClick={descriptionEdit.startEditing}
                 title="Click to edit"
               >
-                {poll.description || "Click to add description"}
+                {poll.description || "Description"}
               </CardDescription>
             )}
           </CardHeader>
+          <CardContent className="pt-0 pb-4 flex flex-wrap items-center gap-2">
+            {/* Split button: Poll Link + dropdown for Preview Link */}
+            <div className="flex">
+              <Button
+                size="sm"
+                variant={copiedField === "student" ? "success" : "default"}
+                className="min-w-44 transition-all rounded-r-none"
+                onClick={() => copyToClipboard(participantUrl, "student")}
+              >
+                {copiedField === "student"
+                  ? <Check className="mr-1.5 h-3.5 w-3.5" />
+                  : <Share2 className="mr-1.5 h-3.5 w-3.5" />}
+                {copiedField === "student" ? "URL Copied!" : "Poll Link"}
+              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant={copiedField === "student" ? "success" : "default"}
+                    className="rounded-l-none border-l border-l-white/20 px-2 transition-all"
+                  >
+                    <ChevronDown className="h-3.5 w-3.5" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  <DropdownMenuItem onClick={() => { copyToClipboard(`${participantUrl}?preview=true`, "preview"); window.open(`${participantUrl}?preview=true`, "_blank"); }}>
+                    {copiedField === "preview"
+                      ? <Check className="mr-2 h-4 w-4 text-success" />
+                      : <ExternalLink className="mr-2 h-4 w-4" />}
+                    {copiedField === "preview" ? "URL Copied!" : "Copy and open preview link"}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+            <Button variant={poll.isOpen ? "success" : "warning"} size="sm" onClick={handleToggleOpen} title={poll.isOpen ? "Open" : "Closed"}>
+              {poll.isOpen ? <Unlock className="h-3.5 w-3.5" /> : <Lock className="h-3.5 w-3.5" />}
+            </Button>
+          </CardContent>
         </Card>
 
         {/* Share */}
@@ -511,6 +586,7 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
           copiedField={copiedField}
           onCopy={(text, id) => copyToClipboard(text, id)}
           showControls={true}
+          hidePollRow={true}
           poll={{
             isOpen: poll.isOpen,
             resultsVisible: poll.resultsVisible,
@@ -521,31 +597,20 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
           exportDisabled={!exportResults}
         />
 
-        {/* Edit Topics */}
+        {/* Topics */}
         <Card>
           <CardHeader>
             <div className="flex items-center justify-between">
-              <CardTitle>Edit Topics</CardTitle>
-              <div className="flex items-center gap-4">
-                <div className="text-sm text-muted-foreground">
-                  {claimedCount} / {totalCount} topics claimed
-                </div>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={handleClearAllClaims}
-                  title="Unclaim all topics"
-                >
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Clear All Claims
-                </Button>
+              <CardTitle>Topics</CardTitle>
+              <div className="text-sm text-muted-foreground">
+                {claimedCount} / {totalCount} topics claimed
               </div>
             </div>
           </CardHeader>
           <CardContent className="space-y-6">
             {/* Existing Topics */}
             <div>
-              <div className="space-y-2">
+              <div className="space-y-2" ref={topicsContainerRef}>
                 {(previewTopics ||
                   (optimisticOrder && topics
                     ? optimisticOrder.map(id => topics.find(t => t._id === id)!).filter(Boolean)
@@ -553,12 +618,16 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
                 ).map((topic) => (
                   <div
                     key={topic._id}
+                    data-topic-id={topic._id}
                     draggable
                     onDragStart={() => handleDragStart(topic._id)}
                     onDragOver={(e) => handleDragOver(e, topic._id)}
                     onDragEnd={handleDragEnd}
                     onDrop={() => handleDrop(topic._id)}
-                    className={`flex items-center gap-2 p-3 rounded-lg border md:cursor-move transition-[opacity,transform,background-color] duration-300 ease-in-out ${
+                    onTouchStart={() => handleTouchStart(topic._id)}
+                    onTouchMove={handleTouchMove}
+                    onTouchEnd={handleTouchEnd}
+                    className={`flex items-center gap-2 p-3 rounded-lg border cursor-move transition-[opacity,transform,background-color] duration-300 ease-in-out ${
                       draggedTopicId === topic._id
                         ? "opacity-40 bg-muted"
                         : "bg-accent border-border"
@@ -566,36 +635,8 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
                     style={{ transition: "all 0.3s ease-in-out" }}
                     title="Drag to reorder topics"
                   >
-                    {/* Mobile reorder buttons */}
-                    <div className="flex flex-col gap-1 md:hidden">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleMoveUp(topic._id);
-                        }}
-                        className="p-0 h-4 w-4"
-                        disabled={topics.findIndex((t) => t._id === topic._id) === 0}
-                      >
-                        <ChevronUp className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleMoveDown(topic._id);
-                        }}
-                        className="p-0 h-4 w-4"
-                        disabled={topics.findIndex((t) => t._id === topic._id) === topics.length - 1}
-                      >
-                        <ChevronDown className="h-4 w-4" />
-                      </Button>
-                    </div>
-
-                    {/* Desktop drag handle */}
-                    <GripVertical className="h-5 w-5 text-gray-400 flex-shrink-0 hidden md:block" />
+                    {/* Drag handle */}
+                    <GripVertical className="h-5 w-5 text-gray-400 flex-shrink-0" />
 
                     <div className="flex-1">
                       {editingTopicId === topic._id ? (
@@ -657,7 +698,7 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
                       className="text-red-600 hover:text-red-700 hover:bg-red-50"
                       title="Delete this topic"
                     >
-                      Delete
+                      <Trash2 className="h-4 w-4" />
                     </Button>
                   </div>
                 ))}
@@ -666,7 +707,7 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
 
             {/* Add New Topics */}
             <div>
-              <form onSubmit={handleAddTopics} className="space-y-4">
+              <form onSubmit={handleAddTopics} className="space-y-2">
                 <Textarea
                   value={newTopics}
                   onChange={(e) => setNewTopics(e.target.value)}
@@ -675,19 +716,21 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
                   className="font-mono"
                   title="Enter topics, one per line"
                 />
-                <Button type="submit" disabled={isAddingTopics} title="Add new topics (one per line)">
-                  {isAddingTopics ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Adding...
-                    </>
-                  ) : (
-                    <>
-                      <Plus className="mr-2 h-4 w-4" />
-                      Add Topics
-                    </>
-                  )}
-                </Button>
+                <div className="flex justify-end">
+                  <Button type="submit" disabled={isAddingTopics || !newTopics.trim()} title="Add new topics (one per line)">
+                    {isAddingTopics ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Saving...
+                      </>
+                    ) : (
+                      <>
+                        <Plus className="mr-2 h-4 w-4" />
+                        Save
+                      </>
+                    )}
+                  </Button>
+                </div>
               </form>
             </div>
           </CardContent>
@@ -697,13 +740,20 @@ export default function AdminManagePage({ params }: { params: Promise<{ pollId: 
         <Card className="border-red-200">
           <CardHeader>
             <CardTitle className="text-red-600">Danger Zone</CardTitle>
-            <CardDescription>
-              Permanently delete this poll and all associated data
-            </CardDescription>
           </CardHeader>
-          <CardContent>
+          <CardContent className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleClearAllClaims}
+              title="Unclaim all topics"
+            >
+              <RotateCcw className="mr-2 h-4 w-4" />
+              Clear All Claims
+            </Button>
             <Button
               variant="destructive"
+              size="sm"
               onClick={handleDeletePoll}
               title="Permanently delete this poll and all data"
             >

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,20 +1,21 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { useRouter } from "next/navigation";
 import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Slider } from "@/components/ui/slider";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Loader2, CircleHelp } from "lucide-react";
 import { ShareLinks } from "@/components/ShareLinks";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { SavedPoll } from "@/types/poll";
 import { MAX_SAVED_POLLS } from "@/lib/constants";
 import { ErrorMessage } from "@/components/shared/ErrorMessage";
@@ -36,23 +37,19 @@ export default function AdminPage() {
   } | null>(null);
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
 
+  const { isAnonymous, tier } = useCurrentUser();
+  const usage = useQuery(api.polls.myPollUsage);
+
+  // localStorage fallback for anonymous users (polls not linked to a server account)
   const [savedPolls, setSavedPolls] = useLocalStorage<SavedPoll[]>("myPolls", []);
   const { copiedId: copiedField, copyToClipboard } = useCopyToClipboard();
 
   const createPoll = useMutation(api.polls.create);
 
   const savePollToLocalStorage = (pollId: string, adminToken: string, pollTitle: string) => {
-    const newPoll: SavedPoll = {
-      pollId,
-      adminToken,
-      title: pollTitle,
-      createdAt: Date.now(),
-    };
-
+    const newPoll: SavedPoll = { pollId, adminToken, title: pollTitle, createdAt: Date.now() };
     const existing = savedPolls.filter((p) => p.pollId !== pollId);
-    const updated = [newPoll, ...existing].slice(0, MAX_SAVED_POLLS);
-
-    setSavedPolls(updated);
+    setSavedPolls([newPoll, ...existing].slice(0, MAX_SAVED_POLLS));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -62,10 +59,7 @@ export default function AdminPage() {
     setError(null);
     setIsCreating(true);
     try {
-      const topicLabels = topics
-        .split("\n")
-        .map((t) => t.trim())
-        .filter((t) => t);
+      const topicLabels = topics.split("\n").map((t) => t.trim()).filter((t) => t);
 
       const result = await createPoll({
         title: title.trim(),
@@ -77,14 +71,16 @@ export default function AdminPage() {
       });
 
       setCreatedPoll(result);
-      savePollToLocalStorage(result.pollId, result.adminToken, title.trim());
-    } catch (error) {
-      setError(getErrorMessage(error));
+      // Keep localStorage for anonymous users so they can find the poll
+      if (isAnonymous) {
+        savePollToLocalStorage(result.pollId, result.adminToken, title.trim());
+      }
+    } catch (err) {
+      setError(getErrorMessage(err));
     } finally {
       setIsCreating(false);
     }
   };
-
 
   if (createdPoll) {
     const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
@@ -93,8 +89,8 @@ export default function AdminPage() {
     const resultsUrl = `${baseUrl}/r/${createdPoll.pollId}`;
 
     return (
-      <div className="min-h-screen bg-background p-4 py-8">
-        <div className="max-w-3xl mx-auto space-y-4">
+      <div className="min-h-screen bg-background p-4 py-4">
+        <div className="max-w-3xl mx-auto space-y-2">
           <ShareLinks
             participantUrl={studentUrl}
             resultsUrl={resultsUrl}
@@ -102,25 +98,15 @@ export default function AdminPage() {
             onCopy={(text, id) => copyToClipboard(text, id)}
             successMessage="Poll Created Successfully!"
           />
-
           <Card>
             <CardContent className="pt-6 space-y-2">
-              <Button
-                variant="default"
-                className="w-full"
-                onClick={() => router.push(adminUrl)}
-              >
+              <Button variant="default" className="w-full" onClick={() => router.push(adminUrl)}>
                 Go to Admin Panel
               </Button>
               <Button
                 variant="outline"
                 className="w-full"
-                onClick={() => {
-                  setCreatedPoll(null);
-                  setTitle("");
-                  setDescription("");
-                  setTopics("");
-                }}
+                onClick={() => { setCreatedPoll(null); setTitle(""); setDescription(""); setTopics(""); }}
               >
                 Create Another Poll
               </Button>
@@ -131,12 +117,28 @@ export default function AdminPage() {
     );
   }
 
+  const expiryDays = tier === "anonymous" ? 30 : tier === "free" ? 180 : null;
+
   return (
-    <div className="min-h-screen bg-background p-4 py-8">
+    <div className="min-h-screen bg-background p-4 py-4">
       <div className="max-w-2xl mx-auto">
         <Card>
           <CardHeader>
-            <CardTitle className="text-2xl">Create New Poll</CardTitle>
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-2xl">Create New Poll</CardTitle>
+              {usage && (
+                <span className="text-sm text-muted-foreground">
+                  {usage.used}/{usage.limit} polls used
+                </span>
+              )}
+            </div>
+            {expiryDays && (
+              <p className="text-xs text-muted-foreground mt-1">
+                {tier === "anonymous"
+                  ? `Polls expire after ${expiryDays} days. Sign in first to keep them for longer.`
+                  : `Polls expire after ${expiryDays} days.`}
+              </p>
+            )}
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit} className="space-y-4">
@@ -162,7 +164,6 @@ export default function AdminPage() {
                 />
               </div>
 
-              {/* Advanced Options */}
               {showAdvancedOptions && (
                 <div className="space-y-4">
                   <div className="space-y-2">
@@ -193,35 +194,18 @@ export default function AdminPage() {
                       </Popover>
                     </div>
                     <div className="flex gap-2">
-                      <Button
-                        type="button"
-                        variant={pollType === "claims" ? "default" : "outline"}
-                        className="flex-1"
-                        onClick={() => setPollType("claims")}
-                      >
+                      <Button type="button" variant={pollType === "claims" ? "default" : "outline"} className="flex-1" onClick={() => setPollType("claims")}>
                         Claims
                       </Button>
-                      <Button
-                        type="button"
-                        variant={pollType === "standard" ? "default" : "outline"}
-                        className="flex-1"
-                        onClick={() => setPollType("standard")}
-                      >
+                      <Button type="button" variant={pollType === "standard" ? "default" : "outline"} className="flex-1" onClick={() => setPollType("standard")}>
                         Standard
                       </Button>
                     </div>
                   </div>
 
                   <div className="space-y-2">
-                    <Label htmlFor="description">
-                      Description
-                    </Label>
-                    <Input
-                      id="description"
-                      value={description}
-                      onChange={(e) => setDescription(e.target.value)}
-                      placeholder=""
-                    />
+                    <Label htmlFor="description">Description</Label>
+                    <Input id="description" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="" />
                   </div>
 
                   <div className="space-y-3">
@@ -233,11 +217,8 @@ export default function AdminPage() {
                         onChange={(e) => setRequireName(e.target.checked)}
                         className="w-4 h-4 rounded border-gray-300"
                       />
-                      <Label htmlFor="requireName" className="cursor-pointer">
-                        Require name
-                      </Label>
+                      <Label htmlFor="requireName" className="cursor-pointer">Require name</Label>
                     </div>
-
                     {requireName && (
                       <div className="space-y-2 pl-6">
                         <Label htmlFor="membersPerGroup" className="text-sm text-muted-foreground">
@@ -245,18 +226,13 @@ export default function AdminPage() {
                         </Label>
                         <div className="flex items-center gap-4">
                           <Input
-                            type="number"
-                            min={1}
-                            max={10}
+                            type="number" min={1} max={10}
                             value={membersPerGroup}
                             onChange={(e) => setMembersPerGroup(parseInt(e.target.value) || 1)}
                             className="w-20 text-center"
                           />
                           <Slider
-                            id="membersPerGroup"
-                            min={1}
-                            max={10}
-                            step={1}
+                            id="membersPerGroup" min={1} max={10} step={1}
                             value={[membersPerGroup]}
                             onValueChange={(value) => setMembersPerGroup(value[0])}
                             className="flex-1"
@@ -295,10 +271,7 @@ export default function AdminPage() {
 
               <Button type="submit" className="w-full" disabled={isCreating}>
                 {isCreating ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Creating Poll...
-                  </>
+                  <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Creating Poll...</>
                 ) : (
                   "Create Poll"
                 )}
@@ -306,7 +279,6 @@ export default function AdminPage() {
             </form>
           </CardContent>
         </Card>
-
       </div>
     </div>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Space_Grotesk } from "next/font/google";
 import "./globals.css";
 import { ConvexClientProvider } from "./ConvexClientProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
+import { NavBar } from "@/components/NavBar";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -43,7 +44,10 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <ConvexClientProvider>{children}</ConvexClientProvider>
+          <ConvexClientProvider>
+              <NavBar />
+              {children}
+            </ConvexClientProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,51 +7,66 @@ import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { RecentPolls } from "@/components/RecentPolls";
-import { ThemeToggle } from "@/components/ThemeToggle";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { SavedPoll } from "@/types/poll";
 
 export default function Home() {
   const router = useRouter();
+  const { isAnonymous, isLoading: userLoading, tier } = useCurrentUser();
+
+  // Server-side polls for signed-in (non-anonymous) users
+  const serverPolls = useQuery(
+    api.polls.myPolls,
+    !userLoading && !isAnonymous ? {} : "skip"
+  );
+
+  // localStorage fallback for anonymous users
   const [savedPolls, setSavedPolls] = useLocalStorage<SavedPoll[]>("myPolls", []);
   const [pollIdsToCheck, setPollIdsToCheck] = useState<string[]>([]);
 
-  // Extract poll IDs when savedPolls loads
   useEffect(() => {
-    if (savedPolls.length > 0) {
+    if (isAnonymous && savedPolls.length > 0) {
       setPollIdsToCheck(savedPolls.map((p) => p.pollId));
     }
-  }, [savedPolls]);
+  }, [isAnonymous, savedPolls]);
 
-  // Validate which polls still exist
   const existingPollIds = useQuery(
     api.polls.validatePolls,
-    pollIdsToCheck.length > 0 ? { pollIds: pollIdsToCheck } : "skip"
+    isAnonymous && pollIdsToCheck.length > 0 ? { pollIds: pollIdsToCheck } : "skip"
   );
 
-  // Clean up non-existent polls
   useEffect(() => {
     if (!existingPollIds || savedPolls.length === 0) return;
-
-    const validPolls = savedPolls.filter((poll) =>
-      existingPollIds.includes(poll.pollId)
-    );
-
-    if (validPolls.length !== savedPolls.length) {
-      // Some polls were deleted, update state (useLocalStorage handles persistence)
-      setSavedPolls(validPolls);
-    }
+    const validPolls = savedPolls.filter((poll) => existingPollIds.includes(poll.pollId));
+    if (validPolls.length !== savedPolls.length) setSavedPolls(validPolls);
   }, [existingPollIds, savedPolls]);
 
+  // Build display list: server-side for signed-in users, localStorage for anonymous
+  const displayPolls: SavedPoll[] = isAnonymous
+    ? savedPolls
+    : (serverPolls ?? []).map((p) => ({
+        pollId: p.pollId,
+        title: p.title,
+        adminToken: p.adminToken,
+        createdAt: p.createdAt,
+      }));
+
+  const tierLabel = tier === "pro" ? "Pro" : tier === "free" ? "Free" : null;
+
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center p-4">
-      <div className="fixed top-4 right-4 z-50">
-        <ThemeToggle />
-      </div>
-      <div className="w-full max-w-2xl space-y-4">
+    <div className="min-h-screen bg-background p-4">
+      <div className="w-full max-w-2xl mx-auto space-y-2">
         <Card>
           <CardHeader className="text-center">
-            <CardTitle className="text-4xl font-display font-bold mb-2">Claims Poll!</CardTitle>
+            <CardTitle className="text-4xl font-display font-bold mb-2">
+              Claims Poll
+              {tierLabel && (
+                <span className="ml-2 text-sm font-sans font-normal text-muted-foreground align-middle">
+                  {tierLabel}
+                </span>
+          )}
+            </CardTitle>
             <CardDescription className="text-base">
               No repeat topics
               <br />
@@ -59,21 +74,17 @@ export default function Home() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            {/* Create New Poll Button */}
-            <div className="text-center">
-              <Button
-                size="lg"
-                onClick={() => router.push("/admin")}
-                className="w-full"
-              >
-                Create New Poll
-              </Button>
-            </div>
+            <Button
+              size="lg"
+              onClick={() => router.push("/admin")}
+              className="w-full"
+            >
+              Create New Poll
+            </Button>
           </CardContent>
         </Card>
 
-        {/* My Recent Polls */}
-        <RecentPolls polls={savedPolls} />
+        <RecentPolls polls={displayPolls} />
       </div>
     </div>
   );

--- a/components.json
+++ b/components.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "registries": {}
+}

--- a/components/AutoAnonymousAuth.tsx
+++ b/components/AutoAnonymousAuth.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useConvexAuth } from "convex/react";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useEffect, useRef } from "react";
+
+/**
+ * Silently signs in as an anonymous user on first visit so every visitor
+ * gets a stable userId for poll ownership tracking.
+ */
+export function AutoAnonymousAuth() {
+  const { isAuthenticated, isLoading } = useConvexAuth();
+  const { signIn } = useAuthActions();
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (isLoading || isAuthenticated || attempted.current) return;
+    attempted.current = true;
+    void signIn("anonymous");
+  }, [isLoading, isAuthenticated, signIn]);
+
+  return null;
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,8 +1,14 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Rabbit } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Rabbit, LogOut } from "lucide-react";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { SignInDialog } from "@/components/SignInDialog";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 interface NavBarProps {
   showHomeButton?: boolean;
@@ -10,18 +16,65 @@ interface NavBarProps {
 
 export function NavBar({ showHomeButton = false }: NavBarProps) {
   const router = useRouter();
+  const { signOut } = useAuthActions();
+  const { isLoading, isAnonymous, email, name, image } = useCurrentUser();
+  const [signInOpen, setSignInOpen] = useState(false);
+
+  const initial = (name ?? email ?? "?")[0].toUpperCase();
 
   return (
-    <div className="border-b bg-card">
-      <div className="max-w-7xl mx-auto px-4 py-2">
-        <Button
-          variant="ghost"
-          onClick={() => router.push("/")}
-          className="p-0 h-auto w-auto hover:bg-transparent"
-        >
-          <Rabbit className="h-7 w-7 text-info" />
-        </Button>
+    <>
+      <div className="border-b bg-card">
+        <div className="max-w-7xl mx-auto px-4 py-1 flex items-center justify-between">
+          <Button
+            variant="ghost"
+            onClick={() => router.push("/")}
+            className="p-0 h-auto w-auto hover:bg-transparent"
+          >
+            <Rabbit className="h-5 w-5 text-info" />
+          </Button>
+
+          <div className="flex items-center gap-2">
+          <ThemeToggle />
+          {!isLoading && (
+            isAnonymous ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setSignInOpen(true)}
+              >
+                Sign in
+              </Button>
+            ) : (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button variant="ghost" size="icon" className="rounded-full h-6 w-6 p-0 overflow-hidden">
+                    {image ? (
+                      <img src={image} alt={name ?? email ?? "User"} className="h-6 w-6 rounded-full object-cover" />
+                    ) : (
+                      <span className="h-6 w-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-medium">
+                        {initial}
+                      </span>
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent align="end" className="w-44 p-1">
+                  <button
+                    onClick={() => void signOut()}
+                    className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                  >
+                    <LogOut className="h-3.5 w-3.5" />
+                    Sign out
+                  </button>
+                </PopoverContent>
+              </Popover>
+            )
+          )}
+          </div>
+        </div>
       </div>
-    </div>
+
+      <SignInDialog open={signInOpen} onOpenChange={setSignInOpen} />
+    </>
   );
 }

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -48,7 +48,7 @@ export function NavBar({ showHomeButton = false }: NavBarProps) {
             ) : (
               <Popover>
                 <PopoverTrigger asChild>
-                  <Button variant="ghost" size="icon" className="rounded-full h-6 w-6 p-0 overflow-hidden">
+                  <Button variant="ghost" size="icon" className="rounded-full h-6 w-6 p-0 overflow-hidden" aria-label={name ?? email ?? "User menu"}>
                     {image ? (
                       <img src={image} alt={name ?? email ?? "User"} className="h-6 w-6 rounded-full object-cover" />
                     ) : (

--- a/components/RecentPolls.tsx
+++ b/components/RecentPolls.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { SavedPoll } from "@/types/poll";
 
@@ -9,8 +8,6 @@ interface RecentPollsProps {
 }
 
 export function RecentPolls({ polls }: RecentPollsProps) {
-  const router = useRouter();
-
   if (polls.length === 0) return null;
 
   return (
@@ -19,18 +16,16 @@ export function RecentPolls({ polls }: RecentPollsProps) {
         const adminUrl = `/admin/${poll.pollId}?token=${poll.adminToken}`;
 
         return (
-          <Card
-            key={poll.pollId}
-            onClick={() => router.push(adminUrl)}
-            className="hover:bg-accent hover:border-info transition-colors cursor-pointer"
-          >
-            <CardContent className="pt-4">
-              <h4 className="font-semibold">{poll.title}</h4>
-              <p className="text-xs text-muted-foreground mt-0.5">
-                Created {new Date(poll.createdAt).toLocaleDateString()}
-              </p>
-            </CardContent>
-          </Card>
+          <a key={poll.pollId} href={adminUrl} className="block">
+            <Card className="hover:bg-accent hover:border-info transition-colors cursor-pointer">
+              <CardContent className="pt-4">
+                <h4 className="font-semibold">{poll.title}</h4>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Created {new Date(poll.createdAt).toLocaleDateString()}
+                </p>
+              </CardContent>
+            </Card>
+          </a>
         );
       })}
     </div>

--- a/components/RecentPolls.tsx
+++ b/components/RecentPolls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { SavedPoll } from "@/types/poll";
 
 interface RecentPollsProps {
@@ -14,32 +14,25 @@ export function RecentPolls({ polls }: RecentPollsProps) {
   if (polls.length === 0) return null;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-lg">My Recent Polls</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-3">
-          {polls.map((poll) => {
-            const adminUrl = `/admin/${poll.pollId}?token=${poll.adminToken}`;
+    <div className="space-y-2">
+      {polls.map((poll) => {
+        const adminUrl = `/admin/${poll.pollId}?token=${poll.adminToken}`;
 
-            return (
-              <div
-                key={poll.pollId}
-                onClick={() => router.push(adminUrl)}
-                className="p-4 border rounded-lg hover:bg-accent hover:border-info transition-colors cursor-pointer"
-              >
-                <div>
-                  <h4 className="font-semibold">{poll.title}</h4>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Created {new Date(poll.createdAt).toLocaleDateString()}
-                  </p>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </CardContent>
-    </Card>
+        return (
+          <Card
+            key={poll.pollId}
+            onClick={() => router.push(adminUrl)}
+            className="hover:bg-accent hover:border-info transition-colors cursor-pointer"
+          >
+            <CardContent className="pt-4">
+              <h4 className="font-semibold">{poll.title}</h4>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Created {new Date(poll.createdAt).toLocaleDateString()}
+              </p>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
   );
 }

--- a/components/ShareLinks.tsx
+++ b/components/ShareLinks.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { CopyableInput } from "@/components/shared/CopyableInput";
-import { ExternalLink, Download, Lock, Unlock } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Share2, ExternalLink, Lock, Unlock, Eye, EyeOff, Download, Check, HelpCircle, ChevronDown } from "lucide-react";
 
 interface ShareLinksProps {
   participantUrl: string;
@@ -12,6 +14,7 @@ interface ShareLinksProps {
   onCopy: (text: string, field: string) => void;
   successMessage?: string;
   showControls?: boolean;
+  hidePollRow?: boolean;
   poll?: {
     isOpen: boolean;
     resultsVisible?: boolean;
@@ -29,195 +32,104 @@ export function ShareLinks({
   onCopy,
   successMessage,
   showControls = false,
+  hidePollRow = false,
   poll,
   onToggleOpen,
   onToggleResultsVisible,
   onExportCSV,
   exportDisabled = false,
 }: ShareLinksProps) {
+  const resultsVisible = poll?.resultsVisible ?? true;
+  const [helpOpen, setHelpOpen] = useState(false);
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Share</CardTitle>
-        {successMessage && (
+    <Card className="relative">
+      <Tooltip open={helpOpen} onOpenChange={setHelpOpen}>
+        <TooltipTrigger asChild>
+          <button
+            className="absolute top-3 right-3 text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setHelpOpen(v => !v)}
+          >
+            <HelpCircle className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="left">Share the results link. Hide the results.</TooltipContent>
+      </Tooltip>
+      {successMessage && (
+        <CardHeader>
           <CardDescription className="text-success font-medium">
             {successMessage}
           </CardDescription>
-        )}
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="space-y-2">
-          <p className="text-sm text-muted-foreground">
-            Share this link with participants
-          </p>
-          {/* Mobile Layout */}
-          <div className="md:hidden space-y-2">
-            <CopyableInput
-              value={participantUrl}
-              onCopy={() => onCopy(participantUrl, "student")}
-              isCopied={copiedField === "student"}
-            />
-            <div className="flex gap-2">
-              <Button
-                onClick={() => window.open(`${participantUrl}?preview=true`, "_blank")}
-                className="flex-1"
-                title="Preview poll as a participant"
-              >
-                <ExternalLink className="mr-2 h-4 w-4" />
-                Preview
-              </Button>
-              {showControls && poll && onToggleOpen && (
-                <Button
-                  variant={poll.isOpen ? "success" : "warning"}
-                  onClick={onToggleOpen}
-                  className="flex-1"
-                  title={poll.isOpen ? "Click to close poll" : "Click to open poll"}
-                >
-                  {poll.isOpen ? (
-                    <>
-                      <Unlock className="mr-2 h-4 w-4" />
-                      Poll is Open
-                    </>
-                  ) : (
-                    <>
-                      <Lock className="mr-2 h-4 w-4" />
-                      Poll is Closed
-                    </>
-                  )}
-                </Button>
-              )}
-            </div>
-          </div>
-          {/* Desktop Layout */}
-          <div className="hidden md:flex gap-2">
-            <CopyableInput
-              value={participantUrl}
-              onCopy={() => onCopy(participantUrl, "student")}
-              isCopied={copiedField === "student"}
-            />
-            <Button
-              onClick={() => window.open(`${participantUrl}?preview=true`, "_blank")}
-              className="w-36 shrink-0"
-              title="Preview poll as a participant"
-            >
-              <ExternalLink className="mr-2 h-4 w-4" />
-              Preview
+        </CardHeader>
+      )}
+      <CardContent className={`${successMessage ? "pt-0" : "pt-4"} space-y-3`}>
+
+        {/* Poll row */}
+        {!hidePollRow && <div className="flex flex-wrap items-center gap-2">
+          <p className="text-2xl font-semibold leading-none tracking-tight w-24 shrink-0">Poll</p>
+          <Button
+            size="sm"
+            variant={copiedField === "student" ? "success" : "default"}
+            className="px-8 transition-all"
+            onClick={() => onCopy(participantUrl, "student")}
+          >
+            {copiedField === "student"
+              ? <Check className="mr-1.5 h-3.5 w-3.5" />
+              : <Share2 className="mr-1.5 h-3.5 w-3.5" />}
+            {copiedField === "student" ? "URL Copied!" : "Share"}
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => window.open(`${participantUrl}?preview=true`, "_blank")} title="Preview">
+            <ExternalLink className="h-3.5 w-3.5" />
+          </Button>
+          {showControls && poll && onToggleOpen && (
+            <Button variant={poll.isOpen ? "success" : "warning"} size="sm" onClick={onToggleOpen} title={poll.isOpen ? "Open" : "Closed"}>
+              {poll.isOpen ? <Unlock className="h-3.5 w-3.5" /> : <Lock className="h-3.5 w-3.5" />}
             </Button>
-            {showControls && poll && onToggleOpen && (
-              <Button
-                variant={poll.isOpen ? "success" : "warning"}
-                onClick={onToggleOpen}
-                className="w-44 shrink-0"
-                title={poll.isOpen ? "Click to close poll" : "Click to open poll"}
-              >
-                {poll.isOpen ? (
-                  <>
-                    <Unlock className="mr-2 h-4 w-4" />
-                    Poll is Open
-                  </>
-                ) : (
-                  <>
-                    <Lock className="mr-2 h-4 w-4" />
-                    Poll is Closed
-                  </>
+          )}
+        </div>}
+
+        {/* Results row */}
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Split button: Results Link + dropdown for CSV download */}
+          <div className="flex">
+            <Button
+              size="sm"
+              variant={copiedField === "results" ? "success" : "default"}
+              className="min-w-44 transition-all rounded-r-none"
+              onClick={() => onCopy(resultsUrl, "results")}
+            >
+              {copiedField === "results"
+                ? <Check className="mr-1.5 h-3.5 w-3.5" />
+                : <Share2 className="mr-1.5 h-3.5 w-3.5" />}
+              {copiedField === "results" ? "URL Copied!" : "Results Link"}
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="sm"
+                  variant={copiedField === "results" ? "success" : "default"}
+                  className="rounded-l-none border-l border-l-white/20 px-2 transition-all"
+                >
+                  <ChevronDown className="h-3.5 w-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                {showControls && onExportCSV && (
+                  <DropdownMenuItem onClick={onExportCSV} disabled={exportDisabled}>
+                    <Download className="mr-2 h-4 w-4" />
+                    Download CSV
+                  </DropdownMenuItem>
                 )}
-              </Button>
-            )}
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
-          {copiedField === "student" && (
-            <p className="text-xs text-success font-medium">✓ Copied to clipboard</p>
+          {showControls && poll && onToggleResultsVisible && (
+            <Button variant={resultsVisible ? "success" : "warning"} size="sm" onClick={onToggleResultsVisible} title={resultsVisible ? "Visible" : "Hidden"}>
+              {resultsVisible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+            </Button>
           )}
         </div>
-        <div className="space-y-2">
-          <p className="text-sm text-muted-foreground">
-            Share the realtime results
-          </p>
-          {/* Mobile Layout */}
-          <div className="md:hidden space-y-2">
-            <CopyableInput
-              value={resultsUrl}
-              onCopy={() => onCopy(resultsUrl, "results")}
-              isCopied={copiedField === "results"}
-            />
-            <div className="flex gap-2">
-              <Button
-                onClick={() => window.open(resultsUrl, "_blank")}
-                className="flex-1"
-                title="View results board"
-              >
-                <ExternalLink className="mr-2 h-4 w-4" />
-                Results
-              </Button>
-              {showControls && poll && onToggleResultsVisible && (
-                <Button
-                  variant={(poll.resultsVisible ?? true) ? "success" : "warning"}
-                  onClick={onToggleResultsVisible}
-                  className="flex-1"
-                  title={(poll.resultsVisible ?? true) ? "Click to hide results" : "Click to show results"}
-                >
-                  {(poll.resultsVisible ?? true) ? (
-                    <>
-                      <Unlock className="mr-2 h-4 w-4" />
-                      Results Visible
-                    </>
-                  ) : (
-                    <>
-                      <Lock className="mr-2 h-4 w-4" />
-                      Results Hidden
-                    </>
-                  )}
-                </Button>
-              )}
-            </div>
-          </div>
-          {/* Desktop Layout */}
-          <div className="hidden md:flex gap-2">
-            <CopyableInput
-              value={resultsUrl}
-              onCopy={() => onCopy(resultsUrl, "results")}
-              isCopied={copiedField === "results"}
-            />
-            <Button
-              onClick={() => window.open(resultsUrl, "_blank")}
-              className="w-36 shrink-0"
-              title="View results board"
-            >
-              <ExternalLink className="mr-2 h-4 w-4" />
-              Results
-            </Button>
-            {showControls && poll && onToggleResultsVisible && (
-              <Button
-                variant={(poll.resultsVisible ?? true) ? "success" : "warning"}
-                onClick={onToggleResultsVisible}
-                className="w-44 shrink-0"
-                title={(poll.resultsVisible ?? true) ? "Click to hide results" : "Click to show results"}
-              >
-                {(poll.resultsVisible ?? true) ? (
-                  <>
-                    <Unlock className="mr-2 h-4 w-4" />
-                    Results Visible
-                  </>
-                ) : (
-                  <>
-                    <Lock className="mr-2 h-4 w-4" />
-                    Results Hidden
-                  </>
-                )}
-              </Button>
-            )}
-          </div>
-          {copiedField === "results" && (
-            <p className="text-xs text-success font-medium">✓ Copied to clipboard</p>
-          )}
-        </div>
-        {showControls && onExportCSV && (
-          <div className="pt-2">
-            <Button variant="outline" onClick={onExportCSV} disabled={exportDisabled} title="Export results as CSV">
-              <Download className="mr-2 h-4 w-4" />
-              Download CSV
-            </Button>
-          </div>
-        )}
+
       </CardContent>
     </Card>
   );

--- a/components/SignInDialog.tsx
+++ b/components/SignInDialog.tsx
@@ -50,9 +50,11 @@ export function SignInDialog({ open, onOpenChange }: SignInDialogProps) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [isGoogleLoading, setIsGoogleLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleGoogleSignIn = () => {
+    setIsGoogleLoading(true);
     void signIn("google");
   };
 
@@ -82,6 +84,7 @@ export function SignInDialog({ open, onOpenChange }: SignInDialogProps) {
       setEmail("");
       setPassword("");
       setError(null);
+      setIsGoogleLoading(false);
     }
     onOpenChange(newOpen);
   };
@@ -101,8 +104,13 @@ export function SignInDialog({ open, onOpenChange }: SignInDialogProps) {
             variant="outline"
             className="w-full gap-3"
             onClick={handleGoogleSignIn}
+            disabled={isGoogleLoading}
           >
-            <GoogleLogo />
+            {isGoogleLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <GoogleLogo />
+            )}
             Sign in with Google
           </Button>
 

--- a/components/SignInDialog.tsx
+++ b/components/SignInDialog.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState } from "react";
+import { useAuthActions } from "@convex-dev/auth/react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2 } from "lucide-react";
+import { getErrorMessage } from "@/lib/errors";
+
+interface SignInDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// Inline Google logo SVG (no external CDN dependency)
+function GoogleLogo() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+      <path
+        fill="#4285F4"
+        d="M16.51 8H8.98v3h4.3c-.18 1-.74 1.48-1.6 2.04v2.01h2.6a7.8 7.8 0 0 0 2.38-5.88c0-.57-.05-.66-.15-1.18z"
+      />
+      <path
+        fill="#34A853"
+        d="M8.98 17c2.16 0 3.97-.72 5.3-1.94l-2.6-2.01c-.72.49-1.63.84-2.7.84-2.08 0-3.84-1.4-4.47-3.29H1.84v2.07A8 8 0 0 0 8.98 17z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M4.51 10.6A4.8 4.8 0 0 1 4.26 9c0-.56.1-1.1.25-1.6V5.33H1.84A8 8 0 0 0 .98 9c0 1.29.31 2.51.86 3.67l2.67-2.07z"
+      />
+      <path
+        fill="#EA4335"
+        d="M8.98 3.58c1.17 0 2.23.4 3.06 1.2l2.3-2.3A8 8 0 0 0 8.98 1a8 8 0 0 0-7.14 4.33l2.67 2.07c.63-1.89 2.39-3.82 4.47-3.82z"
+      />
+    </svg>
+  );
+}
+
+export function SignInDialog({ open, onOpenChange }: SignInDialogProps) {
+  const { signIn } = useAuthActions();
+  const [showEmailForm, setShowEmailForm] = useState(false);
+  const [isSignUp, setIsSignUp] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleGoogleSignIn = () => {
+    void signIn("google");
+  };
+
+  const handleEmailSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsLoading(true);
+    try {
+      const formData = new FormData();
+      formData.set("email", email);
+      formData.set("password", password);
+      formData.set("flow", isSignUp ? "signUp" : "signIn");
+      await signIn("password", formData);
+      onOpenChange(false);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      // Reset state on close
+      setShowEmailForm(false);
+      setIsSignUp(false);
+      setEmail("");
+      setPassword("");
+      setError(null);
+    }
+    onOpenChange(newOpen);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-center text-xl font-display">
+            Sign in to Claims Poll
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Primary: Google */}
+          <Button
+            variant="outline"
+            className="w-full gap-3"
+            onClick={handleGoogleSignIn}
+          >
+            <GoogleLogo />
+            Sign in with Google
+          </Button>
+
+          {/* Secondary: email+password (hidden by default) */}
+          {!showEmailForm ? (
+            <div className="text-center pt-1">
+              <button
+                type="button"
+                onClick={() => setShowEmailForm(true)}
+                className="text-xs text-muted-foreground underline-offset-4 hover:underline"
+              >
+                Other sign-in options
+              </button>
+            </div>
+          ) : (
+            <form onSubmit={handleEmailSubmit} className="space-y-3">
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-background px-2 text-muted-foreground">
+                    {isSignUp ? "Create account" : "Email sign-in"}
+                  </span>
+                </div>
+              </div>
+
+              {error && (
+                <p className="text-sm text-destructive text-center">{error}</p>
+              )}
+
+              <div className="space-y-1">
+                <Label htmlFor="signin-email">Email</Label>
+                <Input
+                  id="signin-email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  autoFocus
+                />
+              </div>
+
+              <div className="space-y-1">
+                <Label htmlFor="signin-password">Password</Label>
+                <Input
+                  id="signin-password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+              </div>
+
+              <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : isSignUp ? (
+                  "Create account"
+                ) : (
+                  "Sign in"
+                )}
+              </Button>
+
+              <div className="text-center">
+                <button
+                  type="button"
+                  onClick={() => { setIsSignUp(!isSignUp); setError(null); }}
+                  className="text-xs text-muted-foreground underline-offset-4 hover:underline"
+                >
+                  {isSignUp
+                    ? "Already have an account? Sign in"
+                    : "Don't have an account? Create one"}
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -32,7 +32,7 @@ export function ThemeToggle() {
       ) : (
         <Moon className="h-4 w-4" />
       )}
-      <span className="sr-only">Toggle theme</span>
+      <span className="sr-only">{isDark ? "Switch to light mode" : "Switch to dark mode"}</span>
     </Button>
   );
 }

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -15,17 +15,17 @@ export function ThemeToggle() {
   }, []);
 
   if (!mounted) {
-    return <Button variant="outline" size="icon" className="h-9 w-9" />;
+    return <Button variant="ghost" size="icon" className="h-6 w-6 border-none" />;
   }
 
   const isDark = theme === "dark";
 
   return (
     <Button
-      variant="outline"
+      variant="ghost"
       size="icon"
       onClick={() => setTheme(isDark ? "light" : "dark")}
-      className="h-9 w-9"
+      className="h-6 w-6 border-none"
     >
       {isDark ? (
         <Sun className="h-4 w-4" />

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1 p-4", className)}
     {...props}
   />
 ))
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-4 pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -70,7 +70,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn("flex items-center p-4 pt-0", className)}
     {...props}
   />
 ))

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { Check, ChevronRight, Circle } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+))
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+))
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,12 +13,16 @@ import type {
   FilterApi,
   FunctionReference,
 } from "convex/server";
+import type * as auth from "../auth.js";
+import type * as crons from "../crons.js";
 import type * as groups from "../groups.js";
+import type * as http from "../http.js";
 import type * as lib_enrichers from "../lib/enrichers.js";
 import type * as lib_validators from "../lib/validators.js";
 import type * as polls from "../polls.js";
 import type * as selections from "../selections.js";
 import type * as topics from "../topics.js";
+import type * as users from "../users.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -29,12 +33,16 @@ import type * as topics from "../topics.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
+  crons: typeof crons;
   groups: typeof groups;
+  http: typeof http;
   "lib/enrichers": typeof lib_enrichers;
   "lib/validators": typeof lib_validators;
   polls: typeof polls;
   selections: typeof selections;
   topics: typeof topics;
+  users: typeof users;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -1,0 +1,8 @@
+export default {
+  providers: [
+    {
+      domain: process.env.CONVEX_SITE_URL,
+      applicationID: "convex",
+    },
+  ],
+};

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,0 +1,8 @@
+import Google from "@auth/core/providers/google";
+import { Password } from "@convex-dev/auth/providers/Password";
+import { Anonymous } from "@convex-dev/auth/providers/Anonymous";
+import { convexAuth } from "@convex-dev/auth/server";
+
+export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
+  providers: [Google, Password, Anonymous],
+});

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,13 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+// Delete polls older than POLL_MAX_AGE_DAYS (default: 180) every day at 2 AM UTC
+crons.daily(
+  "cleanup old polls",
+  { hourUTC: 2, minuteUTC: 0 },
+  internal.polls.cleanupOldPolls,
+);
+
+export default crons;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -3,7 +3,8 @@ import { internal } from "./_generated/api";
 
 const crons = cronJobs();
 
-// Delete polls older than POLL_MAX_AGE_DAYS (default: 180) every day at 2 AM UTC
+// Delete expired polls daily at 2 AM UTC.
+// Expiry is tier-based: POLL_MAX_AGE_DAYS_ANONYMOUS (default: 30 days) and POLL_MAX_AGE_DAYS_FREE (default: 180 days). Pro polls never expire.
 crons.daily(
   "cleanup old polls",
   { hourUTC: 2, minuteUTC: 0 },

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,0 +1,8 @@
+import { httpRouter } from "convex/server";
+import { auth } from "./auth";
+
+const http = httpRouter();
+
+auth.addHttpRoutes(http);
+
+export default http;

--- a/convex/polls.ts
+++ b/convex/polls.ts
@@ -13,6 +13,16 @@ const TIER_POLL_LIMITS = {
 
 type Tier = keyof typeof TIER_POLL_LIMITS;
 
+// Max topics per poll (module-level so it's parsed once)
+const MAX_TOPICS_PER_POLL = parseInt(process.env.MAX_TOPICS_PER_POLL ?? "") || 100;
+
+// Resolve a user document to their effective Tier
+function resolveTier(user: { tier?: string | null; isAnonymous?: boolean | null } | null): Tier {
+  if (!user) return "anonymous";
+  const isAnonymous = user.isAnonymous === true;
+  return (user.tier as Tier) ?? (isAnonymous ? "anonymous" : "free");
+}
+
 // Generate a cryptographically secure admin token
 function generateAdminToken(): string {
   return crypto.randomUUID().replace(/-/g, "") + crypto.randomUUID().replace(/-/g, "");
@@ -39,10 +49,9 @@ export const create = mutation({
     }
 
     // Validate topic count
-    const maxTopicsPerPoll = parseInt(process.env.MAX_TOPICS_PER_POLL ?? "100");
     const validTopics = args.topicLabels.filter((l) => l.trim());
-    if (validTopics.length > maxTopicsPerPoll) {
-      throw new Error(`Too many topics (max ${maxTopicsPerPoll} per poll).`);
+    if (validTopics.length > MAX_TOPICS_PER_POLL) {
+      throw new Error(`Too many topics (max ${MAX_TOPICS_PER_POLL} per poll).`);
     }
 
     // Get authenticated user and their tier
@@ -50,8 +59,7 @@ export const create = mutation({
     let tier: Tier = "anonymous";
     if (userId) {
       const user = await ctx.db.get(userId);
-      const isAnonymous = user?.isAnonymous === true;
-      tier = (user?.tier as Tier) ?? (isAnonymous ? "anonymous" : "free");
+      tier = resolveTier(user);
     }
 
     // Enforce tier-based poll limit
@@ -77,7 +85,7 @@ export const create = mutation({
     }
 
     // Global total cap (DB size backstop)
-    const maxTotalPolls = parseInt(process.env.MAX_TOTAL_POLLS ?? "500");
+    const maxTotalPolls = parseInt(process.env.MAX_TOTAL_POLLS ?? "") || 500;
     const existingPolls = await ctx.db.query("polls").take(maxTotalPolls + 1);
     if (existingPolls.length > maxTotalPolls) {
       throw new Error(
@@ -147,14 +155,13 @@ export const myPollUsage = query({
     if (!userId) return { used: 0, limit: TIER_POLL_LIMITS.anonymous, tier: "anonymous" as Tier };
 
     const user = await ctx.db.get(userId);
-    const isAnonymous = user?.isAnonymous === true;
-    const tier: Tier = (user?.tier as Tier) ?? (isAnonymous ? "anonymous" : "free");
+    const tier = resolveTier(user);
     const limit = TIER_POLL_LIMITS[tier];
 
     const polls = await ctx.db
       .query("polls")
       .withIndex("by_user", (q) => q.eq("userId", userId))
-      .collect();
+      .take(limit + 1);
 
     return { used: polls.length, limit, tier };
   },
@@ -258,10 +265,9 @@ export const addTopics = mutation({
       .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
       .collect();
 
-    const maxTopicsPerPoll = parseInt(process.env.MAX_TOPICS_PER_POLL ?? "100");
     const incomingCount = args.topicLabels.filter((l) => l.trim()).length;
-    if (existingTopics.length + incomingCount > maxTopicsPerPoll) {
-      throw new Error(`Topic limit reached (max ${maxTopicsPerPoll} per poll).`);
+    if (existingTopics.length + incomingCount > MAX_TOPICS_PER_POLL) {
+      throw new Error(`Topic limit reached (max ${MAX_TOPICS_PER_POLL} per poll).`);
     }
 
     let maxOrder = existingTopics.length > 0
@@ -383,48 +389,29 @@ export const deletePoll = mutation({
 export const cleanupOldPolls = internalMutation({
   args: {},
   handler: async (ctx) => {
-    const maxAnonDays = parseInt(process.env.POLL_MAX_AGE_DAYS_ANONYMOUS ?? "30");
-    const maxFreeDays = parseInt(process.env.POLL_MAX_AGE_DAYS_FREE ?? "180");
+    const maxAnonDays = parseInt(process.env.POLL_MAX_AGE_DAYS_ANONYMOUS ?? "") || 30;
+    const maxFreeDays = parseInt(process.env.POLL_MAX_AGE_DAYS_FREE ?? "") || 180;
 
     const now = Date.now();
     const anonCutoff = now - maxAnonDays * 24 * 60 * 60 * 1000;
-    // Use the longer of the two for the initial filter (no need to load pro polls)
     const freeCutoff = now - maxFreeDays * 24 * 60 * 60 * 1000;
 
-    // Fetch all polls older than the free cutoff (pros are never expired so we don't need to load them)
+    // Fetch all polls older than the anonymous cutoff (the shorter window).
+    // Pro polls are skipped inside the loop; free polls are only deleted if older than freeCutoff.
     const candidates = await ctx.db
       .query("polls")
-      .withIndex("by_createdAt", (q) => q.lt("createdAt", freeCutoff))
-      .collect();
-
-    // Also fetch anonymous/legacy polls older than anonCutoff that were missed above
-    const anonCandidates = await ctx.db
-      .query("polls")
-      .withIndex("by_createdAt", (q) =>
-        q.gte("createdAt", freeCutoff).lt("createdAt", anonCutoff > freeCutoff ? anonCutoff : freeCutoff)
-      )
+      .withIndex("by_createdAt", (q) => q.lt("createdAt", anonCutoff))
       .collect();
 
     const toDelete = new Set<Id<"polls">>();
 
-    // All polls older than free cutoff are eligible (check tier below)
     for (const poll of candidates) {
       const owner = poll.userId ? await ctx.db.get(poll.userId) : null;
-      const isAnonymous = owner?.isAnonymous === true;
-      const tier: Tier = (owner?.tier as Tier) ?? (isAnonymous ? "anonymous" : "free");
+      const tier = resolveTier(owner);
 
       if (tier === "pro") continue; // pro polls never expire
+      if (tier === "free" && poll.createdAt >= freeCutoff) continue; // free poll not old enough
       toDelete.add(poll._id);
-    }
-
-    // Polls between anonCutoff and freeCutoff: only delete if anonymous/legacy
-    for (const poll of anonCandidates) {
-      if (poll.createdAt >= anonCutoff) continue; // not old enough for anonymous expiry
-      const owner = poll.userId ? await ctx.db.get(poll.userId) : null;
-      const isAnonymous = owner?.isAnonymous === true;
-      const tier: Tier = (owner?.tier as Tier) ?? (isAnonymous ? "anonymous" : "free");
-
-      if (tier === "anonymous") toDelete.add(poll._id);
     }
 
     let deleted = 0;

--- a/convex/polls.ts
+++ b/convex/polls.ts
@@ -1,7 +1,17 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
+import { mutation, query, internalMutation } from "./_generated/server";
 import { Id } from "./_generated/dataModel";
 import { validateAdminAccess } from "./lib/validators";
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+// Tier poll limits
+const TIER_POLL_LIMITS = {
+  anonymous: 2,
+  free: 5,
+  pro: 10,
+} as const;
+
+type Tier = keyof typeof TIER_POLL_LIMITS;
 
 // Generate a cryptographically secure admin token
 function generateAdminToken(): string {
@@ -24,9 +34,55 @@ export const create = mutation({
     const pollType = args.pollType ?? "claims";
     const requireParticipantNames = args.requireParticipantNames ?? true;
 
-    // Validate membersPerGroup is between 1 and 10
     if (membersPerGroup < 1 || membersPerGroup > 10) {
       throw new Error("Members per group must be between 1 and 10");
+    }
+
+    // Validate topic count
+    const maxTopicsPerPoll = parseInt(process.env.MAX_TOPICS_PER_POLL ?? "100");
+    const validTopics = args.topicLabels.filter((l) => l.trim());
+    if (validTopics.length > maxTopicsPerPoll) {
+      throw new Error(`Too many topics (max ${maxTopicsPerPoll} per poll).`);
+    }
+
+    // Get authenticated user and their tier
+    const userId = await getAuthUserId(ctx);
+    let tier: Tier = "anonymous";
+    if (userId) {
+      const user = await ctx.db.get(userId);
+      const isAnonymous = user?.isAnonymous === true;
+      tier = (user?.tier as Tier) ?? (isAnonymous ? "anonymous" : "free");
+    }
+
+    // Enforce tier-based poll limit
+    const pollLimit = TIER_POLL_LIMITS[tier];
+    if (userId) {
+      const userPolls = await ctx.db
+        .query("polls")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .take(pollLimit + 1);
+      if (userPolls.length >= pollLimit) {
+        if (tier === "anonymous") {
+          throw new Error(
+            `Anonymous users can create up to ${pollLimit} polls. Sign up for a free account to create more.`
+          );
+        } else if (tier === "free") {
+          throw new Error(
+            `Free accounts can create up to ${pollLimit} polls. Upgrade to Pro for more.`
+          );
+        } else {
+          throw new Error(`Poll limit reached (max ${pollLimit}).`);
+        }
+      }
+    }
+
+    // Global total cap (DB size backstop)
+    const maxTotalPolls = parseInt(process.env.MAX_TOTAL_POLLS ?? "500");
+    const existingPolls = await ctx.db.query("polls").take(maxTotalPolls + 1);
+    if (existingPolls.length > maxTotalPolls) {
+      throw new Error(
+        `Service poll limit reached. Please try again later.`
+      );
     }
 
     // Create the poll
@@ -40,6 +96,7 @@ export const create = mutation({
       pollType,
       requireParticipantNames,
       createdAt: Date.now(),
+      userId: userId ?? undefined,
     });
 
     // Create topics with order
@@ -56,6 +113,50 @@ export const create = mutation({
     }
 
     return { pollId, adminToken };
+  },
+});
+
+// Get the current user's polls (server-side My Polls)
+export const myPolls = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) return null;
+
+    const polls = await ctx.db
+      .query("polls")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .order("desc")
+      .collect();
+
+    return polls.map((p) => ({
+      pollId: p._id,
+      title: p.title,
+      isOpen: p.isOpen,
+      createdAt: p.createdAt,
+      adminToken: p.adminToken,
+    }));
+  },
+});
+
+// Get the current user's poll count and limit
+export const myPollUsage = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) return { used: 0, limit: TIER_POLL_LIMITS.anonymous, tier: "anonymous" as Tier };
+
+    const user = await ctx.db.get(userId);
+    const isAnonymous = user?.isAnonymous === true;
+    const tier: Tier = (user?.tier as Tier) ?? (isAnonymous ? "anonymous" : "free");
+    const limit = TIER_POLL_LIMITS[tier];
+
+    const polls = await ctx.db
+      .query("polls")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+
+    return { used: polls.length, limit, tier };
   },
 });
 
@@ -80,7 +181,6 @@ export const validatePolls = query({
           existingIds.push(pollId);
         }
       } catch (e) {
-        // Invalid ID format or poll doesn't exist, skip it
         continue;
       }
     }
@@ -97,11 +197,7 @@ export const toggleOpen = mutation({
   },
   handler: async (ctx, args) => {
     const poll = await validateAdminAccess(ctx, args.pollId, args.adminToken);
-
-    await ctx.db.patch(args.pollId, {
-      isOpen: !poll.isOpen,
-    });
-
+    await ctx.db.patch(args.pollId, { isOpen: !poll.isOpen });
     return { isOpen: !poll.isOpen };
   },
 });
@@ -114,12 +210,8 @@ export const toggleResultsVisible = mutation({
   },
   handler: async (ctx, args) => {
     const poll = await validateAdminAccess(ctx, args.pollId, args.adminToken);
-
     const newValue = !(poll.resultsVisible ?? true);
-    await ctx.db.patch(args.pollId, {
-      resultsVisible: newValue,
-    });
-
+    await ctx.db.patch(args.pollId, { resultsVisible: newValue });
     return { resultsVisible: newValue };
   },
 });
@@ -138,9 +230,7 @@ export const updatePollDetails = mutation({
     const updates: { title?: string; description?: string } = {};
 
     if (args.title !== undefined) {
-      if (args.title.trim() === "") {
-        throw new Error("Title cannot be empty");
-      }
+      if (args.title.trim() === "") throw new Error("Title cannot be empty");
       updates.title = args.title.trim();
     }
 
@@ -149,7 +239,6 @@ export const updatePollDetails = mutation({
     }
 
     await ctx.db.patch(args.pollId, updates);
-
     return { success: true };
   },
 });
@@ -164,11 +253,16 @@ export const addTopics = mutation({
   handler: async (ctx, args) => {
     await validateAdminAccess(ctx, args.pollId, args.adminToken);
 
-    // Get current max order
     const existingTopics = await ctx.db
       .query("topics")
       .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
       .collect();
+
+    const maxTopicsPerPoll = parseInt(process.env.MAX_TOPICS_PER_POLL ?? "100");
+    const incomingCount = args.topicLabels.filter((l) => l.trim()).length;
+    if (existingTopics.length + incomingCount > maxTopicsPerPoll) {
+      throw new Error(`Topic limit reached (max ${maxTopicsPerPoll} per poll).`);
+    }
 
     let maxOrder = existingTopics.length > 0
       ? Math.max(...existingTopics.map(t => t.order))
@@ -207,7 +301,6 @@ export const exportResults = query({
 
     topics.sort((a, b) => a.order - b.order);
 
-    // Standard poll: aggregate vote counts in a single pass
     if (poll.pollType === "standard") {
       const allVotes = await ctx.db
         .query("votes")
@@ -230,7 +323,6 @@ export const exportResults = query({
       }));
     }
 
-    // Claims poll: include the claiming group's member names
     const results = [];
     for (const topic of topics) {
       if (topic.selectedByGroupId) {
@@ -239,7 +331,6 @@ export const exportResults = query({
           const memberNames = group.members
             .map((m) => `${m.firstName} ${m.lastName}`)
             .join("; ");
-
           results.push({
             topic: topic.label,
             members: memberNames,
@@ -248,12 +339,7 @@ export const exportResults = query({
           });
         }
       } else {
-        results.push({
-          topic: topic.label,
-          members: "",
-          selectedAt: "",
-          votes: null,
-        });
+        results.push({ topic: topic.label, members: "", selectedAt: "", votes: null });
       }
     }
 
@@ -270,39 +356,101 @@ export const deletePoll = mutation({
   handler: async (ctx, args) => {
     await validateAdminAccess(ctx, args.pollId, args.adminToken);
 
-    // Delete all topics for this poll
     const topics = await ctx.db
       .query("topics")
       .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
       .collect();
+    for (const topic of topics) await ctx.db.delete(topic._id);
 
-    for (const topic of topics) {
-      await ctx.db.delete(topic._id);
-    }
-
-    // Delete all groups for this poll
     const groups = await ctx.db
       .query("groups")
       .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
       .collect();
+    for (const group of groups) await ctx.db.delete(group._id);
 
-    for (const group of groups) {
-      await ctx.db.delete(group._id);
-    }
-
-    // Delete all votes for this poll (standard polls)
     const votes = await ctx.db
       .query("votes")
       .withIndex("by_poll", (q) => q.eq("pollId", args.pollId))
       .collect();
+    for (const vote of votes) await ctx.db.delete(vote._id);
 
-    for (const vote of votes) {
-      await ctx.db.delete(vote._id);
+    await ctx.db.delete(args.pollId);
+    return { success: true };
+  },
+});
+
+// Auto-cleanup: delete polls based on owner's tier expiry rules
+export const cleanupOldPolls = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const maxAnonDays = parseInt(process.env.POLL_MAX_AGE_DAYS_ANONYMOUS ?? "30");
+    const maxFreeDays = parseInt(process.env.POLL_MAX_AGE_DAYS_FREE ?? "180");
+
+    const now = Date.now();
+    const anonCutoff = now - maxAnonDays * 24 * 60 * 60 * 1000;
+    // Use the longer of the two for the initial filter (no need to load pro polls)
+    const freeCutoff = now - maxFreeDays * 24 * 60 * 60 * 1000;
+
+    // Fetch all polls older than the free cutoff (pros are never expired so we don't need to load them)
+    const candidates = await ctx.db
+      .query("polls")
+      .withIndex("by_createdAt", (q) => q.lt("createdAt", freeCutoff))
+      .collect();
+
+    // Also fetch anonymous/legacy polls older than anonCutoff that were missed above
+    const anonCandidates = await ctx.db
+      .query("polls")
+      .withIndex("by_createdAt", (q) =>
+        q.gte("createdAt", freeCutoff).lt("createdAt", anonCutoff > freeCutoff ? anonCutoff : freeCutoff)
+      )
+      .collect();
+
+    const toDelete = new Set<Id<"polls">>();
+
+    // All polls older than free cutoff are eligible (check tier below)
+    for (const poll of candidates) {
+      const owner = poll.userId ? await ctx.db.get(poll.userId) : null;
+      const isAnonymous = owner?.isAnonymous === true;
+      const tier: Tier = (owner?.tier as Tier) ?? (isAnonymous ? "anonymous" : "free");
+
+      if (tier === "pro") continue; // pro polls never expire
+      toDelete.add(poll._id);
     }
 
-    // Delete the poll itself
-    await ctx.db.delete(args.pollId);
+    // Polls between anonCutoff and freeCutoff: only delete if anonymous/legacy
+    for (const poll of anonCandidates) {
+      if (poll.createdAt >= anonCutoff) continue; // not old enough for anonymous expiry
+      const owner = poll.userId ? await ctx.db.get(poll.userId) : null;
+      const isAnonymous = owner?.isAnonymous === true;
+      const tier: Tier = (owner?.tier as Tier) ?? (isAnonymous ? "anonymous" : "free");
 
-    return { success: true };
+      if (tier === "anonymous") toDelete.add(poll._id);
+    }
+
+    let deleted = 0;
+    for (const pollId of toDelete) {
+      const topics = await ctx.db
+        .query("topics")
+        .withIndex("by_poll", (q) => q.eq("pollId", pollId))
+        .collect();
+      for (const topic of topics) await ctx.db.delete(topic._id);
+
+      const groups = await ctx.db
+        .query("groups")
+        .withIndex("by_poll", (q) => q.eq("pollId", pollId))
+        .collect();
+      for (const group of groups) await ctx.db.delete(group._id);
+
+      const votes = await ctx.db
+        .query("votes")
+        .withIndex("by_poll", (q) => q.eq("pollId", pollId))
+        .collect();
+      for (const vote of votes) await ctx.db.delete(vote._id);
+
+      await ctx.db.delete(pollId);
+      deleted++;
+    }
+
+    return { deleted };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,22 +1,48 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
+import { authTables } from "@convex-dev/auth/server";
 
 export default defineSchema({
+  ...authTables,
+
+  // Extend the users table with a tier field
+  users: defineTable({
+    name: v.optional(v.string()),
+    image: v.optional(v.string()),
+    email: v.optional(v.string()),
+    emailVerificationTime: v.optional(v.number()),
+    phone: v.optional(v.string()),
+    phoneVerificationTime: v.optional(v.number()),
+    isAnonymous: v.optional(v.boolean()),
+    // Subscription tier: anonymous (default) | free (signed in) | pro (manually set)
+    tier: v.optional(v.union(v.literal("anonymous"), v.literal("free"), v.literal("pro"))),
+  })
+    .index("email", ["email"])
+    .index("phone", ["phone"]),
+
   polls: defineTable({
     title: v.string(),
     description: v.optional(v.string()),
     isOpen: v.boolean(),
-    resultsVisible: v.optional(v.boolean()), // Whether results page is publicly visible (defaults to true)
+    resultsVisible: v.optional(v.boolean()),
     adminToken: v.string(),
-    membersPerGroup: v.optional(v.number()), // 1-10, how many members required per group (defaults to 1)
-    pollType: v.optional(v.union(v.literal("claims"), v.literal("standard"))), // Type of poll: "claims" (exclusive) or "standard" (voting)
-    requireParticipantNames: v.optional(v.boolean()), // Whether to require participant names (defaults to true)
-    createdAt: v.number(), // Date.now()
-  }),
+    membersPerGroup: v.optional(v.number()),
+    pollType: v.optional(v.union(v.literal("claims"), v.literal("standard"))),
+    requireParticipantNames: v.optional(v.boolean()),
+    createdAt: v.number(),
+    // Auth fields (new)
+    userId: v.optional(v.id("users")),
+    // Legacy rate-limiting field (deprecated, kept for backwards compat)
+    creatorDeviceId: v.optional(v.string()),
+  })
+    .index("by_createdAt", ["createdAt"])
+    .index("by_user", ["userId"])
+    .index("by_creator_createdAt", ["creatorDeviceId", "createdAt"]),
+
   topics: defineTable({
     pollId: v.id("polls"),
     label: v.string(),
-    order: v.number(), // Display order (0-based)
+    order: v.number(),
     selectedByGroupId: v.optional(v.id("groups")),
     selectedAt: v.optional(v.number()),
   })
@@ -24,6 +50,7 @@ export default defineSchema({
     .index("by_poll_order", ["pollId", "order"])
     .index("by_poll_label", ["pollId", "label"])
     .index("by_poll_group", ["pollId", "selectedByGroupId"]),
+
   groups: defineTable({
     pollId: v.id("polls"),
     members: v.array(
@@ -34,6 +61,7 @@ export default defineSchema({
     ),
     createdAt: v.number(),
   }).index("by_poll", ["pollId"]),
+
   votes: defineTable({
     pollId: v.id("polls"),
     topicId: v.id("topics"),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,0 +1,25 @@
+import { v } from "convex/values";
+import { query, internalMutation } from "./_generated/server";
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+// Get the current authenticated user (including their tier)
+export const me = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) return null;
+    return await ctx.db.get(userId);
+  },
+});
+
+// Manually set a user's tier (run from Convex dashboard)
+export const setTier = internalMutation({
+  args: {
+    userId: v.id("users"),
+    tier: v.union(v.literal("anonymous"), v.literal("free"), v.literal("pro")),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.userId, { tier: args.tier });
+    return { success: true };
+  },
+});

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -2,13 +2,21 @@ import { v } from "convex/values";
 import { query, internalMutation } from "./_generated/server";
 import { getAuthUserId } from "@convex-dev/auth/server";
 
-// Get the current authenticated user (including their tier)
+// Get the current authenticated user (only the fields the client needs)
 export const me = query({
   args: {},
   handler: async (ctx) => {
     const userId = await getAuthUserId(ctx);
     if (!userId) return null;
-    return await ctx.db.get(userId);
+    const user = await ctx.db.get(userId);
+    if (!user) return null;
+    return {
+      name: user.name,
+      image: user.image,
+      email: user.email,
+      isAnonymous: user.isAnonymous,
+      tier: user.tier,
+    };
   },
 });
 

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useConvexAuth, useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+
+export type Tier = "anonymous" | "free" | "pro";
+
+export interface CurrentUser {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  isAnonymous: boolean;
+  tier: Tier;
+  email?: string;
+  name?: string;
+  image?: string;
+}
+
+export function useCurrentUser(): CurrentUser {
+  const { isAuthenticated, isLoading } = useConvexAuth();
+
+  const user = useQuery(
+    api.users.me,
+    isAuthenticated ? {} : "skip"
+  );
+
+  if (isLoading || !isAuthenticated || user === undefined) {
+    return { isAuthenticated: false, isLoading: true, isAnonymous: true, tier: "anonymous" };
+  }
+
+  return {
+    isAuthenticated: true,
+    isLoading: false,
+    isAnonymous: user?.isAnonymous === true,
+    tier: (user?.tier as Tier) ?? (user?.isAnonymous === true ? "anonymous" : "free"),
+    email: user?.email ?? undefined,
+    name: user?.name ?? undefined,
+    image: user?.image ?? undefined,
+  };
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import { type ClassValue, clsx } from "clsx"
+import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@convex-dev/auth": "^0.0.91",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slider": "^1.3.6",
@@ -452,6 +453,111 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -744,6 +850,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -809,6 +944,46 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -949,6 +1124,37 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -7547,111 +7753,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
       "name": "lop",
       "version": "0.1.0",
       "dependencies": {
+        "@auth/core": "^0.37.4",
+        "@convex-dev/auth": "^0.0.91",
         "@radix-ui/react-alert-dialog": "^1.1.15",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slider": "^1.3.6",
@@ -22,7 +25,7 @@
         "next-themes": "^0.4.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "tailwind-merge": "^3.3.1",
+        "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
@@ -52,6 +55,66 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@auth/core": {
+      "version": "0.37.4",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.37.4.tgz",
+      "integrity": "sha512-HOXJwXWXQRhbBDHlMU0K/6FT1v+wjtzdKhsNg0ZN7/gne6XPsIrjZ4daMcFnbq0Z/vsAbYBinQhhua0d77v7qw==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^5.9.6",
+        "oauth4webapi": "^3.1.1",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@convex-dev/auth": {
+      "version": "0.0.91",
+      "resolved": "https://registry.npmjs.org/@convex-dev/auth/-/auth-0.0.91.tgz",
+      "integrity": "sha512-wLD4hszo3IhhMkwPs6ozWf0cUauwmhOvjUVn0g//kC338n/jApOjeDYWKCrn/qYUkveyDsbag5zrY8mVzA09Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@oslojs/crypto": "^1.0.1",
+        "@oslojs/encoding": "^1.1.0",
+        "cookie": "^1.0.1",
+        "is-network-error": "^1.1.0",
+        "jose": "^5.2.2",
+        "jwt-decode": "^4.0.0",
+        "lucia": "^3.2.0",
+        "oauth4webapi": "^3.1.2",
+        "path-to-regexp": "^6.3.0",
+        "server-only": "^0.0.1"
+      },
+      "bin": {
+        "auth": "dist/bin.cjs"
+      },
+      "peerDependencies": {
+        "@auth/core": "^0.37.0",
+        "convex": "^1.17.0",
+        "react": "^18.2.0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@edge-runtime/primitives": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-6.0.0.tgz",
@@ -73,16 +136,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
@@ -442,6 +495,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@oslojs/asn1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
+      "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/binary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
+      "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/asn1": "1.0.0",
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2388,6 +2481,19 @@
         "convex": "^1.16.4"
       }
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4152,6 +4258,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4388,6 +4506,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4455,6 +4582,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {
@@ -4559,6 +4695,17 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/lucia": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/lucia/-/lucia-3.2.2.tgz",
+      "integrity": "sha512-P1FlFBGCMPMXu+EGdVD9W4Mjm0DqsusmKgO7Xc33mI5X1bklmsQb0hfzPhXomQr9waWIBDsiOjvr1e6BTaUqpA==",
+      "deprecated": "This package has been deprecated. Please see https://lucia-auth.com/lucia-v3/migrate.",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/crypto": "^1.0.1",
+        "@oslojs/encoding": "^1.1.0"
+      }
     },
     "node_modules/lucide-react": {
       "version": "0.545.0",
@@ -4817,6 +4964,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -5109,6 +5265,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5317,6 +5479,25 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -5762,6 +5943,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -6356,9 +6543,9 @@
       }
     },
     "node_modules/tailwind-merge": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
-      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7360,6 +7547,111 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@convex-dev/auth": "^0.0.91",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slider": "^1.3.6",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@auth/core": "^0.37.4",
+    "@convex-dev/auth": "^0.0.91",
     "@radix-ui/react-alert-dialog": "^1.1.15",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slider": "^1.3.6",
@@ -27,7 +30,7 @@
     "next-themes": "^0.4.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "tailwind-merge": "^3.3.1",
+    "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

- **Auth system**: Anonymous (auto), Google OAuth, and email+password (hidden as "Other sign-in options") via `@convex-dev/auth`
- **Tiered limits**: Anonymous=2 polls/30-day expiry, Free=5 polls/180-day expiry, Pro=10 polls/never expire
- **My Polls**: Server-side for signed-in users (by `userId`), localStorage fallback for anonymous
- **Daily cron cleanup**: Respects owner tier before expiring polls
- **NavBar**: Theme toggle, sign-in button, Google avatar or initial for signed-in users
- **UI polish**: Reduced card padding, tighter page spacing, individual poll cards on landing page

## Test plan

- [ ] Anonymous visit: silently signed in, NavBar shows "Sign in" button, admin page shows 0/2 polls
- [ ] Google sign-in: avatar appears in NavBar, admin page shows 0/5 polls with 180-day expiry notice
- [ ] Email sign-up: via "Other sign-in options" hidden link
- [ ] Poll creation: saved to Convex with `userId`, appears in My Polls after sign-in
- [ ] Poll limit enforcement: error on exceeding tier limit
- [ ] Sign out: returns to anonymous session
- [ ] Theme toggle in NavBar works

## Notes

- Set Convex env vars before deploying to prod: `AUTH_SECRET`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `SITE_URL`, `POLL_MAX_AGE_DAYS_ANONYMOUS=30`, `POLL_MAX_AGE_DAYS_FREE=180`
- Run `npx @convex-dev/auth --prod` to generate JWT keys on production deployment
- Add `https://polished-starfish-216.convex.site/api/auth/callback/google` as OAuth redirect URI in Google Cloud Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)